### PR TITLE
updated title and url for existing FIM entry; Added new entry for legacy FIM app

### DIFF
--- a/data/gaTable.yaml
+++ b/data/gaTable.yaml
@@ -886,13 +886,35 @@
 - longName: "Flood Inundation Mapper"
   shortName: "FIM"
   accountName: WIM USGS
+  viewID: '116842326'
+  accountId: '61219868'
+  webPropertyId: UA-61219868-7
+  internalWebPropertyId: '142720692'
+  viewName: All Web Site Data
+  timezone: America/Los_Angeles
+  websiteUrl: https://wimcloud.usgs.gov/apps/FIM/FloodInundationMapper.html
+  botFilteringEnabled: .na.character
+  description: >-
+     The Flood Inundation Mapper (FIM) allows users to explore the full set of inundation maps that shows where
+     flooding would occur given a selected stream condition. Users can also access historical
+     flood information and potential loss estimates based on the severity of the flood. The
+     FIM Mapper helps communities visualize potential flooding scenarios, identify areas and
+     resources that may be at risk, and enhance their local response effort during a flooding event.
+  projectContact: 'Hans Vraga'
+  projectContactEmail: 'hvraga@usgs.gov'
+  analyticsContact: 'Hans Vraga'
+  analyticsContactEmail: 'hvraga@usgs.gov'
+
+- longName: "Flood Inundation Mapper - JS"
+  shortName: "FIM-JS"
+  accountName: WIM USGS
   viewID: '147316934'
   accountId: '61219868'
   webPropertyId: UA-61219868-23
   internalWebPropertyId: '142720692'
   viewName: All Web Site Data
   timezone: America/Los_Angeles
-  websiteUrl: http://wimcloud.usgs.gov/apps/FIM/FloodInundationMapper.html
+  websiteUrl: https://fim.wim.usgs.gov/fim/
   botFilteringEnabled: .na.character
   description: >-
      The Flood Inundation Mapper (FIM) allows users to explore the full set of inundation maps that shows where

--- a/data/gaTable.yaml
+++ b/data/gaTable.yaml
@@ -889,7 +889,7 @@
   viewID: '116842326'
   accountId: '61219868'
   webPropertyId: UA-61219868-7
-  internalWebPropertyId: '142720692'
+  internalWebPropertyId: '111935524'
   viewName: All Web Site Data
   timezone: America/Los_Angeles
   websiteUrl: https://wimcloud.usgs.gov/apps/FIM/FloodInundationMapper.html


### PR DESCRIPTION
I wasn't sure what the `internalWebPropertyId` would be for the new entry (`viewID: '116842326'`) or where it gets assigned. It is currently the same as the the original FIM entry. If you tell me what that ID would be, I can fix it and resubmit the pull request.