### PR TITLE
drop grid from required packages

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -18,9 +18,6 @@ info:
       version: 0.3.10
       name: USGS-VIZLAB/vizlab
       ref: v0.3.10
-    grid:
-      repo: CRAN
-      version: 3.6.0
     usmap:
       repo: CRAN
       version: 0.4.0


### PR DESCRIPTION
This doesn't seem to be necessary and is tied to the R version