### PR TITLE
fix yaml problem

### DIFF
--- a/data/gaTable.yaml
+++ b/data/gaTable.yaml
@@ -1161,7 +1161,7 @@
   viewID: '176409830'
   accountId: '1084444827'
   webPropertyId: UA-1084444827
-  internalWebPropertyId:
+  internalWebPropertyId: ""
   viewName: WMA Drupal Content
   timezone: America/Chicago
   websiteUrl: www.usgs.gov/mission-areas/water-resources

--- a/viz.yaml
+++ b/viz.yaml
@@ -87,6 +87,9 @@ info:
     aws.signature:
       repo: CRAN
       version: 0.2.9
+    ineq:
+      repo: CRAN
+      version: 0.2-13
 fetch:
   -
     id: fetchGA


### PR DESCRIPTION
Empty yaml fields apparently cause this error `Error: Argument 7 is a list, must contain atomic vectors` when gaTable.yaml  is read and then `bind_rows` is used to convert it to a data frame.